### PR TITLE
added redirects to partner's website

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,10 +332,18 @@
           <div class="row">
               <div class="col-md-12">
                   <div style="margin-top:3em;text-align: center;">
+                  <a href="https://ovibees.com/venturefrontierlanka/" target="_blank">
                   <img src="./assets/img/partners/venture.png" height="80px" style="margin-right:35px;"/>
+                  </a>
+                  <a href="https://thuru.lk/" target="_blank">
                   <img src="./assets/img/partners/thuru.png" height="80px" style="margin-right:35px;"/>
+                  </a>
+                  <a href="https://www.surfedge.lk/" target="_blank">
                   <img src="./assets/img/partners/surfedge.png" height="80px" style="margin-right:35px;"/>
+                  </a>
+                  <a href="https://autochatic.com/#/" target="_blank">
                   <img src="./assets/img/partners/autochatic.png" height="80px"/>
+                  </a>
                   </div>
               </div>
             </div>


### PR DESCRIPTION
The images of the partners' logos at the bottom of the homepage have been converted to links which redirect to the corresponding partner's website.