### PR TITLE
Create example page for team content and add dummy profiles

### DIFF
--- a/src/main/webapp/assets/content/json/dummy-profiles.json
+++ b/src/main/webapp/assets/content/json/dummy-profiles.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Samuel Holmes",
+    "image": "https://placeimg.com/320/320/people",
+    "city": "London"
+  },
+  {
+    "name": "Albert Williamson",
+    "image": "https://placeimg.com/321/321/people",
+    "city": "Melbourne"
+  },
+  {
+    "name": "Robert Fisher",
+    "image": "https://placeimg.com/322/322/people",
+    "city": "Paris"
+  },
+  {
+    "name": "Shirley Hicks",
+    "image": "https://placeimg.com/323/323/people",
+    "city": "New York"
+  },
+  {
+    "name": "Donna Morrison",
+    "image": "https://placeimg.com/324/324/people",
+    "city": "Colombo"
+  },
+  {
+    "name": "Hannah Sims",
+    "image": "https://placeimg.com/325/325/people",
+    "city": "Moscow"
+  },
+  {
+    "name": "Lori Franklin",
+    "image": "https://placeimg.com/326/326/people",
+    "city": "New Delhi"
+  },
+  {
+    "name": "Jason Sanchez",
+    "image": "https://placeimg.com/327/327/people",
+    "city": "Mexico City"
+  },
+  {
+    "name": "Teresa Austin",
+    "image": "https://placeimg.com/328/328/people/",
+    "city": "Canberra"
+  },
+  {
+    "name": "Katherine Carr",
+    "image": "https://placeimg.com/329/329/people/",
+    "city": "Cairo"
+  },
+  {
+    "name": "Margaret Ortiz",
+    "image": "https://placeimg.com/330/330/people",
+    "city": "San Fransisco"
+  },
+  {
+    "name": "Gary Murray",
+    "image": "https://placeimg.com/331/331/people",
+    "city": "Toronto"
+  },
+  {
+    "name": "Jacqueline Ramos",
+    "image": "https://placeimg.com/332/332/people",
+    "city": "Beijing"
+  },
+  {
+    "name": "Kelly Hamilton",
+    "image": "https://placeimg.com/333/333/people",
+    "city": "Tokyo"
+  }
+]

--- a/src/main/webapp/examples/team.html
+++ b/src/main/webapp/examples/team.html
@@ -137,7 +137,7 @@
         loadNavAndFooter('assets/content');  //relative path to content directory
         // link to the navbar, footer content goes here
 
-        loadProfiles();
+        loadProfiles(); // call function to load profiles
     })
 </script>
 

--- a/src/main/webapp/examples/team.html
+++ b/src/main/webapp/examples/team.html
@@ -58,6 +58,11 @@
 <!--Mustache.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
 
+
+<!-- Script for static navbar and footer -->
+<script src="../assets/js/navigation.js"></script>
+
+
 <!--Mustache template for team content-->
 <script type="text/html" id="templateTeam">
     <div class="row">
@@ -86,8 +91,15 @@
     </div>
 </script>
 
-<!--Script for load team data-->
 <script>
+    $(function () {
+        loadNavAndFooter('assets/content');  //relative path to content directory
+        // link to the navbar, footer content goes here
+
+        loadProfiles(); // call function to load profiles
+    });
+
+    //function to load profile data
     function loadProfiles() {
         $.ajax({
             type: 'get',
@@ -124,21 +136,6 @@
                 }
             }
         });
-    }
-
-</script>
-
-<!-- Script for static navbar and footer -->
-<script src="../assets/js/navigation.js"></script>
-
-
-<script>
-    $(function () {
-        loadNavAndFooter('assets/content');  //relative path to content directory
-        // link to the navbar, footer content goes here
-
-        loadProfiles(); // call function to load profiles
-    })
 </script>
 
 

--- a/src/main/webapp/examples/team.html
+++ b/src/main/webapp/examples/team.html
@@ -37,7 +37,7 @@
 
             <div id="teamContent"></div>
 
-            <button id="btn" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
+            <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
         </div>
     </section>
 </main>
@@ -88,44 +88,43 @@
 
 <!--Script for load team data-->
 <script>
-    $.ajax({
-        type: 'get',
-        url: '../assets/content/json/dummy-profiles.json',
-        dataType: 'json',
-        success: function (data) {
+    function loadProfiles() {
+        $.ajax({
+            type: 'get',
+            url: '../assets/content/json/dummy-profiles.json',
+            dataType: 'json',
+            success: function (data) {
 
-            //slice array to two parts
-            if(data.length>=8){
-                let partOne = data.slice(0, 8);
-                let partTwo = data.slice(8);
+                //slice array to two parts
+                if(data.length>=8){
+                    let partOne = data.slice(0, 8);
+                    let partTwo = data.slice(8);
 
-                //mustache render
-                let contentPartOne = Mustache.render($("#templateTeam").html(), {"data": partOne});
-                let contentPartTwo = Mustache.render($("#templateTeam").html(), {"data": partTwo});
+                    //mustache render - part one
+                    let contentPartOne = Mustache.render($("#templateTeam").html(), {"data": partOne});
 
-                //display first 8 profiles
-                $("#teamContent").html(contentPartOne);
+                    //display first 8 profiles
+                    $("#teamContent").html(contentPartOne);
 
-                //hide button
-                $("#btn").click(function () {
-                    $("#teamContent").append(contentPartTwo);
-                    document.getElementById("btn").style.display = "none";
-                });
-            }else{
-                //mustache render
-                let content = Mustache.render($("#templateTeam").html(), {"data": data});
+                    //hide button
+                    $("#btnShowMore").click(function () {
+                        let contentPartTwo = Mustache.render($("#templateTeam").html(), {"data": partTwo});
+                        $("#teamContent").append(contentPartTwo);
+                        document.getElementById("btnShowMore").style.display = "none";
+                    });
+                }else{
+                    //mustache render
+                    let content = Mustache.render($("#templateTeam").html(), {"data": data});
 
-                //display first 8 profiles
-                $("#teamContent").html(content);
+                    //display first 8 profiles
+                    $("#teamContent").html(content);
 
-                //hide button
-                document.getElementById("btn").style.display = "none";
+                    //hide button
+                    $("#btnShowMore").style.display = "none";
+                }
             }
-
-
-
-        }
-    });
+        });
+    }
 
 </script>
 
@@ -135,8 +134,10 @@
 
 <script>
     $(function () {
-        loadNavAndFooter('assets/content')  //relative path to content directory
+        loadNavAndFooter('assets/content');  //relative path to content directory
         // link to the navbar, footer content goes here
+
+        loadProfiles();
     })
 </script>
 

--- a/src/main/webapp/examples/team.html
+++ b/src/main/webapp/examples/team.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description"
+          content="Volunteer driven organisation which empowers students, education institutes and education as a whole in Sri Lanka.">
+    <meta name="author" content="Sustainable Education Foundation">
+    <title>Sustainable Education Foundation</title>
+    <!-- Favicon -->
+    <link href="../assets/img/brand/favicon.png" rel="icon" type="image/png">
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+    <!-- Icons -->
+    <link href="../assets/vendor/nucleo/css/nucleo.css" rel="stylesheet">
+    <link href="../assets/vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+    <!-- Argon CSS -->
+    <link type="text/css" href="../assets/css/argon.css?v=1.0.1" rel="stylesheet">
+    <!-- Global custom CSS -->
+    <link type="text/css" href="../assets/css/global-custom.css" rel="stylesheet">
+
+</head>
+
+<body>
+<header class="header-global">
+    <!--nav bar goes here-->
+</header>
+<!-- to use the dynamic navbar, use this instead of above tag => * <div id="navbar"></div> * -->
+
+<main>
+    <section>
+        <div class="container text-center">
+            <div class="mb-5 text-left h2">
+                <span>Lorem ipsum dolor sit amet</span>
+            </div>
+
+            <div id="teamContent"></div>
+
+            <button id="btn" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <!--footer goes here -->
+</footer>
+
+<!-- to use the dynamic footer, use this instead of above tag => *<div id="footer"></div>* -->
+
+<!-- Core -->
+<script src="../assets/vendor/jquery/jquery.min.js"></script>
+<script src="../assets/vendor/popper/popper.min.js"></script>
+<script src="../assets/vendor/bootstrap/bootstrap.min.js"></script>
+<script src="../assets/vendor/headroom/headroom.min.js"></script>
+<!-- Argon JS -->
+<script src="../assets/js/argon.js?v=1.0.1"></script>
+<!--Mustache.js-->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.3.0/mustache.min.js"></script>
+
+<!--Mustache template for team content-->
+<script type="text/html" id="templateTeam">
+    <div class="row">
+        {{#data}}
+        <div class="col-md-3 col-lg-3 mb-5">
+            <div class="px-4">
+                <div class="imgContainer">
+                    <img src="{{image}}"
+                         class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
+                    >
+                    <div class="imgIcon">
+                        <a href="{{linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
+                            <i class="fa fa-linkedin"></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="pt-4 text-center">
+                    <h5 class="title">
+                        <span class="d-block mb-1">{{name}}</span>
+                        <small class="h6 text-muted">{{city}}</small>
+                    </h5>
+                </div>
+            </div>
+        </div>
+        {{/data}}
+    </div>
+</script>
+
+<!--Script for load team data-->
+<script>
+    $.ajax({
+        type: 'get',
+        url: '../assets/content/json/dummy-profiles.json',
+        dataType: 'json',
+        success: function (data) {
+
+            //slice array to two parts
+            if(data.length>=8){
+                let partOne = data.slice(0, 8);
+                let partTwo = data.slice(8);
+
+                //mustache render
+                let contentPartOne = Mustache.render($("#templateTeam").html(), {"data": partOne});
+                let contentPartTwo = Mustache.render($("#templateTeam").html(), {"data": partTwo});
+
+                //display first 8 profiles
+                $("#teamContent").html(contentPartOne);
+
+                //hide button
+                $("#btn").click(function () {
+                    $("#teamContent").append(contentPartTwo);
+                    document.getElementById("btn").style.display = "none";
+                });
+            }else{
+                //mustache render
+                let content = Mustache.render($("#templateTeam").html(), {"data": data});
+
+                //display first 8 profiles
+                $("#teamContent").html(content);
+
+                //hide button
+                document.getElementById("btn").style.display = "none";
+            }
+
+
+
+        }
+    });
+
+</script>
+
+<!-- Script for static navbar and footer -->
+<script src="../assets/js/navigation.js"></script>
+
+
+<script>
+    $(function () {
+        loadNavAndFooter('assets/content')  //relative path to content directory
+        // link to the navbar, footer content goes here
+    })
+</script>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
## Purpose
> To create a template page to display a set of profiles

## Goals
> This can be used on page sections where we need to show a team/profiles
Ex: Team page, Alumni page,IRC Researchers etc.

## Approach
> - Created dummy data file using JSON.
> - Used Mustache.js to load content to the template.

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? YES

## Related PRs
PR #256 

## Test environment
> Ubuntu 19.04, Google Chrome
 
## Learning
> N/A
