### PR TITLE
Rearrange faq component

### DIFF
--- a/src/main/webapp/examples/components.html
+++ b/src/main/webapp/examples/components.html
@@ -2282,6 +2282,98 @@
             </div>
         </div>
     </section>
+
+    <section>
+        <div class="container">
+            <h2 class="mb-5">
+                <span>FAQ Section Style 2</span>
+            </h2>
+            <div class="row justify-content-center">
+                <div class="col accordian-title">
+                    <button class="btn btn-link text-dark w-100" data-toggle="collapse" data-target="#faq-one">
+                        <div class="row justify-content-center">
+                            <div class="col-6 text-left">
+                                <p class="text-capitalize flex-wrap">How to be a member?</p>
+                            </div>
+                            <div class="col-6 text-right mt-1">
+                                <i class="fa fa-plus-circle text-primary"></i>
+                            </div>
+                        </div>
+                    </button>
+                    <div class="collapse" id="faq-one">
+                        <div class="row justify-content-center">
+                            <div class="col-8 text-left">
+                                <p class="text-muted">
+                                    Anim pariatur cliche reprehenderit, enim eiusmod high life
+                                    accusamus terry richardson ad squid. 3 wolf moon officia
+                                    aute, non cupidatat skateboard dolor brunch. Food truck
+                                    quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+                                    sunt aliqua put a bird on it squid single-origin coffee
+                                    nulla assumenda shoreditch et.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row justify-content-center">
+                <div class="col accordian-title">
+                    <button class="btn btn-link text-dark w-100" data-toggle="collapse" data-target="#faq-two">
+                        <div class="row justify-content-center">
+                            <div class="col-6 text-left">
+                                <p class="text-capitalize">How to be a member?</p>
+                            </div>
+                            <div class="col-6 text-right mt-1">
+                                <i class="fa fa-plus-circle text-primary"></i>
+                            </div>
+                        </div>
+                    </button>
+                    <div class="collapse" id="faq-two">
+                        <div class="row justify-content-center">
+                            <div class="col-8 text-left">
+                                <p class="text-muted">
+                                    Anim pariatur cliche reprehenderit, enim eiusmod high life
+                                    accusamus terry richardson ad squid. 3 wolf moon officia
+                                    aute, non cupidatat skateboard dolor brunch. Food truck
+                                    quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+                                    sunt aliqua put a bird on it squid single-origin coffee
+                                    nulla assumenda shoreditch et.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row justify-content-center">
+                <div class="col accordian-title">
+                    <button class="btn btn-link text-dark w-100" data-toggle="collapse" data-target="#faq-three">
+                        <div class="row justify-content-center">
+                            <div class="col-6 text-left">
+                                <p class="text-capitalize">How to be a member?</p>
+                            </div>
+                            <div class="col-6 text-right mt-1">
+                                &nbsp;<i class="fa fa-plus-circle text-primary"></i>
+                            </div>
+                        </div>
+                    </button>
+                    <div class="collapse" id="faq-three">
+                        <div class="row justify-content-center">
+                            <div class="col-8 text-left">
+                                <p class="text-muted">
+                                    Anim pariatur cliche reprehenderit, enim eiusmod high life
+                                    accusamus terry richardson ad squid. 3 wolf moon officia
+                                    aute, non cupidatat skateboard dolor brunch. Food truck
+                                    quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+                                    sunt aliqua put a bird on it squid single-origin coffee
+                                    nulla assumenda shoreditch et.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
     <!-- end of FAQ Accordion-->
     <!-- Cards section   -->
     <section class="section section-lg section-secondary">
@@ -2741,6 +2833,23 @@
 <!-- Argon JS -->
 <script src="../assets/js/argon.js?v=1.0.1"></script>
 <script src="../assets/js/global-custom-js.js"></script>
+<script>
+    $('.accordian-title').click(function () {
+        if($(this).children('div').hasClass('show')){
+            $(this).removeClass('card shadow rounded');
+            $(this).children('button').children('div').children('div').children('i').removeClass('fa-minus-circle');
+            $(this).children('button').children('div').children('div').children('i').addClass('fa-plus-circle');
+        }else{
+            $('.accordian-title').not(this).children('div').removeClass('show');
+            $('.accordian-title').not(this).removeClass('card shadow rounded');
+            $('.accordian-title').not(this).children('button').children('div').children('div').children('i').removeClass('fa-minus-circle');
+            $('.accordian-title').not(this).children('button').children('div').children('div').children('i').addClass('fa-plus-circle');
+            $(this).addClass('card shadow rounded');
+            $(this).children('button').children('div').children('div').children('i').removeClass('fa-plus-circle');
+            $(this).children('button').children('div').children('div').children('i').addClass('fa-minus-circle');
+        }
+    })
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
Rearrange the faq component 
## Purpose

To make faq component less complicated and solve the mobile view issue

## Goals
Redevelop the faq component 

## Approach
Now there are two styles of faq components and the js part for the second style is at the end of the component.html file 

### Screenshots
![image](https://user-images.githubusercontent.com/45477334/71318176-7641ef80-24b3-11ea-9235-0896cdf63cf9.png)

<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
### Preview Link
<!---  Publish your project to github pages and add the preview link  -->
<!---  go to repo settings > options > git hub pages  > chose master branch > navigate to https://{username}.github.io/{repo-name}  -->

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
ubuntu 19.04
Apache2
Google Chrome 

## Learning
N/A
