### PR TITLE
Fix the sizes of profile images on Onelive page

### DIFF
--- a/src/main/webapp/onelive.html
+++ b/src/main/webapp/onelive.html
@@ -284,7 +284,7 @@
         {{#data}}
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
-                <div class="imgContainer">
+                <div class="hover-profile-card">
                     <img src="{{image}}"
                          class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
@@ -297,7 +297,7 @@
                 <div class="pt-4 text-center">
                     <h5 class="title">
                         <span class="d-block mb-1">{{name}}</span>
-                        <small class="h6 text-muted">{{city}}</small>
+<!--                        <small class="h6 text-muted">{{city}}</small>-->
                     </h5>
                 </div>
             </div>


### PR DESCRIPTION
## Purpose

Resolve Issue #288 

## Goals
Changing the sizes of profile images

## Approach
Added the correct CSS class to the images

### Screenshots
![Uploading SEF_site_-_2019-12-26_14.38.18.png…]()

  
### Preview Link
https://piumal1999.github.io/sef-site/src/main/webapp/onelive

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
Ubuntu 19.04
Google Chrome

## Learning
N/A
