### PR TITLE
Link the FAQ section to learn more button in join_us.html

### DIFF
--- a/src/main/webapp/join_us.html
+++ b/src/main/webapp/join_us.html
@@ -51,7 +51,7 @@
                     </ul>
                 </div>
 
-                <a href="#">
+                <a href="#faq-section">
                     <button class="btn btn-purple text-uppercase mt-3" href="examples">Learn more</button>
                 </a>
             </div>
@@ -72,7 +72,7 @@
                         <li>Programming</li>
                     </ul>
                 </div>
-                <a href="#">
+                <a href="#faq-section">
                     <button class="btn btn-purple text-uppercase mt-3" href="examples">Learn more</button>
                 </a>
             </div>
@@ -86,7 +86,7 @@
     </section>
 
     <!--    FAQ section-->
-    <section class="section section-secondary">
+    <section id="faq-section" class="section section-secondary">
         <div class="container">
             <h2 class="text-center">Frequently Asked Questions</h2>
 


### PR DESCRIPTION
## Purpose
Add a link to the "Learn More" button on the "Join Us" page.
The purpose of this PR is to fix #437 

## Goals
Move the page to the FAQ section in join_us.html when clicking the "Learn More" button on the same page.

## Approach
Added an ID "faq-section" to the FAQ section and linked it to the "Learn More" button.

### Screenshots
-
  
### Preview Link
https://pr-444-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
-

## Test environment
Windows 10, Firefox browser

## Learning
-
