### PR TITLE
Fix linked in font awesome icon

### DIFF
--- a/src/main/webapp/team.html
+++ b/src/main/webapp/team.html
@@ -155,7 +155,7 @@
                     {{#social}}
                     <div class="imgIcon">
                         <a href="https://www.linkedin.com/in/{{linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
-                            <i class="fa fa-linkedin"></i>
+                            <i class="fab fa-linkedin"></i>
                         </a>
                     </div>
                     {{/social}}


### PR DESCRIPTION
## Purpose
Fix issue in font awesome icon in the team page
The purpose of this PR is to fix #514 

## Goals
View the font awesome icon for linked in team page

## Approach
Change old font-awesome class to suit the new version of the font awesome version

### Screenshots
![Screenshot from 2020-02-23 10-52-56](https://user-images.githubusercontent.com/35697678/75104094-c7dd3680-562a-11ea-8351-8a29bc4c5fd2.png)

  
### Preview Link
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-515-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [ ] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
