### PR TITLE
Align hero image to center in archive page

### DIFF
--- a/src/main/webapp/scholarx/archive/index.html
+++ b/src/main/webapp/scholarx/archive/index.html
@@ -67,7 +67,7 @@
             </div>
             <div class="col-md-6">
                 <img src="images/hero-image.svg"
-                     class="img-fluid align-self-center w-75">
+                     class="img-fluid align-self-center w-100">
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #590 

## Goals
This is to fix the image alignment issue in archive page.

## Approach
Changed the CSS class.

### Screenshots
![image](https://user-images.githubusercontent.com/35985674/76441562-a085b800-63e5-11ea-95a8-872272b1b78e.png)

  
### Preview Link
https://pr-594-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
OS: Windows
Browser: chrome
Tested in dev tool devices - pixel2,pixel2 XL,iPhone x,iPhone 6
