### PR TITLE
Fix unavailable profile link in team page

### DIFF
--- a/src/main/webapp/assets/content/json/team.json
+++ b/src/main/webapp/assets/content/json/team.json
@@ -5,7 +5,7 @@
       "description": "Postdoctoral Researcher at Stanford University School of Medicine",
       "image": "hasini.jpeg",
       "social": {
-        "linkedin": "hasini-jayatilaka-3026456a"
+        "linkedin": "hasini-jayatilaka-ph-d-3026456a"
       }
     },
     {


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #595

## Goals
This will fix the unavailable profile link in the team page 

## Approach
Updated the profile id from  hasini-jayatilaka-3026456a to hasini-jayatilaka-ph-d-3026456a
  
### Preview Link
https://pr-596-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
OS: Windows 10
Browser: chrome