### PR TITLE
Add a play button to one live homepage videos

### DIFF
--- a/src/main/webapp/onelive/index.html
+++ b/src/main/webapp/onelive/index.html
@@ -275,7 +275,7 @@
     <div class="col-md-4 mb-5">
         <a href="https://www.youtube.com/watch?v={{snippet.resourceId.videoId}}"
            target="_blank">
-            <div class="card shadow youtube-videos mb-4">
+            <div class="card video-card shadow youtube-videos mb-4">
                 <img src="{{snippet.thumbnails.medium.url}}"
                      alt="Rounded image"
                      class="img-fluid rounded shadow img-full">
@@ -284,6 +284,17 @@
                     <h6 class="small">{{snippet.publishedAt}}</h6>
                     <p class="text-muted">{{snippet.description}}</p>
                 </div>
+                <!-- Change button style by changing btn-youtube into anything you like ex: btn-onelive -->
+                <a class="btn btn-onelive position-absolute hover-element rounded-05-rem"
+                   style="right: 20px; bottom: 20px"
+                   href="https://www.youtube.com/watch?v={{snippet.resourceId.videoId}}" target="_blank">
+                            <span class="original-content">
+                                <i class="fas fa-play"></i>
+                            </span>
+                    <span class="content-on-hover">
+                                Watch Now &nbsp;<i class="fas fa-play fa-sm"></i>
+                            </span>
+                </a>
             </div>
         </a>
     </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
- The purpose of this PR is to fix #657 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- Add a play button to one live homepage videos

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Add a play button to one live `index.html` page videos

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot from 2020-04-19 09-17-06](https://user-images.githubusercontent.com/43912578/79679089-7f07bf80-8220-11ea-98e7-8dfacb42aeb2.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-658-sef-site.surge.sh/onelive/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

