### PR TITLE
Remove the unwanted character + from join-us

### DIFF
--- a/src/main/webapp/join-us.html
+++ b/src/main/webapp/join-us.html
@@ -8,7 +8,7 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         gtag('config', 'UA-167873271-1');
-    </script>+
+    </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="We are always on the lookout for top talent to join our SEF Management Team. If you are skilled in the following one or more areas we would love to hear from you:">


### PR DESCRIPTION
## Purpose
Remove unwanted character from join-us page 
Fix #764 

## Goals
Remove `+` from the join-us page

### Preview Link
https://pr-765-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
- Ubuntu 18.04, Google Chrome
