### PR TITLE
Fix spelling mistake in one-live faq

### DIFF
--- a/src/main/webapp/onelive/index.html
+++ b/src/main/webapp/onelive/index.html
@@ -148,7 +148,7 @@
                                             aria-expanded="false"
                                             aria-controls="collapse-2">
                                         <div class="question-heading">
-                                            Do you have to be a sri lankan to be a speaker?
+                                            Do you have to be a Sri Lankan to be a speaker?
                                         </div>
                                         <div class="text-primary collapse-sign"><i
                                                 class="plusMinusSign fa fa-plus float-right"></i></div>


### PR DESCRIPTION
## Purpose
Fix spelling mistake in One-Live FAQ page.
Fix for #763 

## Goals
Fixed `sri lankan` to `Sri Lankan` in the 2nd FAQ of One-Live page

### Preview Link
https://pr-766-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
- Ubuntu 18.04, Google Chrome
