### PR TITLE
Add fade-in animation to onelive archive cards

### DIFF
--- a/src/main/webapp/onelive/archive/functions.js
+++ b/src/main/webapp/onelive/archive/functions.js
@@ -19,7 +19,7 @@ function loadYoutubeVideos() {
             // Mustache render
             let renderedHtmlContent = Mustache.render(
                 $('#template-youtube-videos').html(), {items: data.items});
-            $('#youtube-videos').append(renderedHtmlContent);
+          $(renderedHtmlContent).appendTo('#youtube-videos').hide().fadeIn(1500);
         }
     });
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #757 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Solving the issue of loading the cards instantly by adding an animation

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Hiding the card and reshowing it with a fade in animation of 1.5s.

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-777-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
