### PR TITLE
Make the team member photos clickable

### DIFF
--- a/src/main/webapp/team.html
+++ b/src/main/webapp/team.html
@@ -168,10 +168,12 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="assets/img/profiles/{{image}}"
-                         class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
-                    >
                     {{#social}}
+                    <a href="https://www.linkedin.com/in/{{linkedin}}">
+                        <img src="assets/img/profiles/{{image}}"
+                             class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
+                        >
+                    </a>
                     <div class="imgIcon">
                         <a href="https://www.linkedin.com/in/{{linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
                             <i class="fab fa-linkedin"></i>


### PR DESCRIPTION
## Purpose
Improve the UX of the team page by making the team members photos clickable and it redirects to the respected LinkedIn profile of the individual.
The purpose of this PR is to fix #798 

## Goals
Add a UX improvement to teams page

## Approach
Added an anchor tag containing the LinkedIn URL of an individual team member.


### Preview Link
https://pr-799-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Ubuntu 20.0, Chrome Browser