### PR TITLE
Make profile images clickable in IRC page

### DIFF
--- a/src/main/webapp/irc.html
+++ b/src/main/webapp/irc.html
@@ -264,9 +264,14 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="assets/img/profiles/{{image}}"
+                    <a href="https://www.linkedin.com/in/{{social.linkedin}}">
+                        <img src="assets/img/profiles/{{image}}"
+                             class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
+                        >
+                    </a>
+                    <!-- <img src="assets/img/profiles/{{image}}"
                          class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
-                    >
+                    > -->
                     <div class="imgIcon">
                         <a href="https://www.linkedin.com/in/{{social.linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
                             <i class="fab fa-linkedin"></i>

--- a/src/main/webapp/irc.html
+++ b/src/main/webapp/irc.html
@@ -269,9 +269,6 @@
                              class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                         >
                     </a>
-                    <!-- <img src="assets/img/profiles/{{image}}"
-                         class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
-                    > -->
                     <div class="imgIcon">
                         <a href="https://www.linkedin.com/in/{{social.linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
                             <i class="fab fa-linkedin"></i>


### PR DESCRIPTION
## Purpose
Provide an additional option to view the LinkedIn profile once the researcher's photo is clicked.
The purpose of this PR is to [fixed: #801](https://github.com/sef-global/sef-site/issues/801#issue-723447221)

## Goal
Add a UX improvement to IRC page.

## Approach
Make the image clickable by adding an anchor tag containing the LinkedIn URL.

## Preview Link
[https://pr-802-sef-site.surge.sh/](https://pr-799-sef-site.surge.sh/) 

## Checklist

- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines (http://bit.ly/sef-best-practices [http://bit.ly/sef-best-practices ](http://bit.ly/sef-best-practices ) )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Ubuntu 18.04, Chrome Browser