### PR TITLE
Add leaderboard link to nav bar and footer

### DIFF
--- a/src/main/webapp/assets/content/static/footer.html
+++ b/src/main/webapp/assets/content/static/footer.html
@@ -67,6 +67,9 @@
                         <li class="nav-item">
                             <a href="/join-us.html" class="nav-link">Join Us</a>
                         </li>
+                        <li class="nav-item">
+                            <a href="https://sefglobal.org/github-leaderboard/" class="nav-link">Leaderboard</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/src/main/webapp/assets/content/static/navbar.html
+++ b/src/main/webapp/assets/content/static/navbar.html
@@ -91,6 +91,12 @@
                         <span class="nav-link-inner--text">Join Us</span>
                     </a>
                 </li>
+                <li class="nav-item dropdown">
+                    <a href="https://sefglobal.org/github-leaderboard/" class="nav-link" role="button">
+                        <i class="fa fa-handshake-o d-lg-none" aria-hidden="true"></i>
+                        <span class="nav-link-inner--text">Leaderboard</span>
+                    </a>
+                </li>
             </ul>
             <ul class="navbar-nav align-items-lg-center ml-lg-auto">
                 <li class="nav-item">


### PR DESCRIPTION
## Purpose
Add leaderboard link to the navigation bar and the footer
The purpose of this PR is to fix #821 

## Goals
Will be able to view the Leaderboard page from the SEF Website.

### Screenshots
Navigation Bar
![Screenshot from 2020-11-25 11-05-43](https://user-images.githubusercontent.com/35697678/100187547-552d1e80-2f0e-11eb-9ecd-6c909ddd7210.png)
Footer
![Screenshot from 2020-11-25 11-05-48](https://user-images.githubusercontent.com/35697678/100187549-56f6e200-2f0e-11eb-9a36-f06a55dc8720.png)

### Preview Link
https://pr-822-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Chrome, Ubuntu 20.04