### PR TITLE
Add more space between 1&2 sections in scholarx-21

### DIFF
--- a/src/main/webapp/scholarx/2021/index.html
+++ b/src/main/webapp/scholarx/2021/index.html
@@ -43,7 +43,7 @@
     <div id="navbar"></div>
 </header>
 
-<section class="section pb-0 bg-gradient-white">
+<section class="section pb-10 bg-gradient-white">
     <div class="container">
         <div class="row row-grid align-items-center justify-content-center">
             <div class="col-md-6">
@@ -62,7 +62,7 @@
     </div>
 </section>
 
-<section class="section pb-5" id="apply" style="background : #e3f6fa">
+<section class="section pb-10" id="apply" style="background : #e3f6fa">
     <div class="container">
         <div class="row row-grid align-items-center justify-content-center">
             <div class="col-md-6 order-lg-1 text-center">


### PR DESCRIPTION
## Purpose
Add more space between section1 and section2 in the scholarx-21
The purpose of this PR is to fix #823 

## Goals
Improves visibility between both the sections

## Approach
Add more space between 1st and 2nd sections

### Screenshots
![Screenshot from 2020-11-30 13-40-29](https://user-images.githubusercontent.com/35697678/100584174-bfc8ca80-3311-11eb-9933-9240c03589b1.png)
  
### Preview Link
https://pr-824-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Chrome, Ubuntu 20.04
