### PR TITLE
Fixing project card logo size over-flow

### DIFF
--- a/assets/css/global-custom.css
+++ b/assets/css/global-custom.css
@@ -542,9 +542,11 @@ body{
 }
 
 /*our projects display section*/
+
 .project-img {
     padding: 15px;
-    width: 200px;
+    max-width: 200px;
+    width: 100%;
     height: auto;
 }
 


### PR DESCRIPTION
## Purpose
Responsive Problem with Project Logos
The purpose of this PR is to fix #881 

## Goals
Stop logos over flowing out of container

## Approach
Using max-width: 200px instead of width: 200px; along with width: 100%

### Screenshots

<img width="920" alt="screenshot" src="https://user-images.githubusercontent.com/21358603/109410749-82dba500-79e0-11eb-94c4-2d32eab13c56.png">

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-881-sef-site.surge.sh/

##  Checklist
- [✔ ] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [ ✔] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ✔] My code follows the style guidelines of this project
- [ ✔] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
Firefox / Chrome - MacOS Catalina

## Learning
N/A
