### PR TITLE
Switch cards in the Scholarx archive page

### DIFF
--- a/scholarx/archive/index.html
+++ b/scholarx/archive/index.html
@@ -94,10 +94,10 @@
                      src="images/card-image.jpg">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">ScholarX 2019</h5>
-                        <p class="card-text">For the 2019 cohort, we had 6 exceptional mentors based in the UK, US,
-                            Canada and Australia who generously volunteered their time.</p>
-                        <a href="2019"
+                        <h5 class="card-title">ScholarX 2020</h5>
+                        <p class="card-text">We expanded the programme to 18 mentors and over 50 mentees.
+                            Our mentors were once again from Fortune500 companies and top Universities.</p>
+                        <a href="2020"
                            class="card-link">View More</a>
                     </div>
                 </div>
@@ -107,10 +107,10 @@
                      src="images/card-image.jpg">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">ScholarX 2020</h5>
-                        <p class="card-text">We expanded the programme to 18 mentors and over 50 mentees.
-                             Our mentors were once again from Fortune500 companies and top Universities.</p>
-                        <a href="2020"
+                        <h5 class="card-title">ScholarX 2019</h5>
+                        <p class="card-text">For the 2019 cohort, we had 6 exceptional mentors based in the UK, US,
+                            Canada and Australia who generously volunteered their time.</p>
+                        <a href="2019"
                            class="card-link">View More</a>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #908

## Goals
To change the position of the 2020 card to the left and the 2019 card to right on the https://sefglobal.org/scholarx/archive/

## Approach
Changed the card positions on the https://sefglobal.org/scholarx/archive/

### Screenshots
![Screenshot from 2021-04-13 08-59-05](https://user-images.githubusercontent.com/63200586/114494397-f0aef980-9c39-11eb-9586-da300866825f.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-913-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
