### PR TITLE
Use iframe of deployed academix to view onsite

### DIFF
--- a/academix.html
+++ b/academix.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167873271-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-167873271-1');
+    </script>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="The International Research Council (IRC) is a community created by the Sustainable Education Foundation (SEF) to showcase the work of Sri Lankan researchers. One of the main goals of IRC is to provide a digital platform to connect our community of researchers who are actively pursuing research projects in various fields all over the world.">
+    <meta name="author" content="Sustainable Education Foundation">
+    <title>Academix | Sustainable Education Foundation</title>
+    <!-- Favicon -->
+    <link href="assets/img/brand/favicon.png" rel="icon" type="image/png">
+    <style type="text/css">
+        html {
+            overflow: auto;
+        }
+
+        html,
+        body,
+        div,
+        iframe {
+            margin: 0px;
+            padding: 0px;
+            height: 100%;
+            border: none;
+        }
+
+        iframe {
+            display: block;
+            width: 100%;
+            border: none;
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+    </style>
+</head>
+<body>
+<iframe src="http://ec2-3-6-91-218.ap-south-1.compute.amazonaws.com:8080/academix/"
+        frameborder="0"
+        marginheight="0"
+        marginwidth="0"
+        width="100%"
+        height="100%"
+        scrolling="auto">
+</iframe>
+</body>
+</html>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #927 

## Goals
- To make Academix visible on the website

## Approach
- Used a fullscreen iframe to directly access the deployed Academix project

### Screenshots
![Screenshot from 2021-04-21 18-36-09](https://user-images.githubusercontent.com/60275681/115559264-2f475280-a2d1-11eb-9ff7-03c96decd89e.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-928-sef-site.surge.sh/academix

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Ubuntu 20.04
Google Chrome Version 87.0.4280.141 (Official Build) (64-bit)
