### PR TITLE
Remove Gitter icon from the footer

### DIFF
--- a/assets/content/static/footer.html
+++ b/assets/content/static/footer.html
@@ -32,11 +32,7 @@
                         data-original-title="Contribute us">
                         <i class="fab fa-github"></i>
                     </a>
-                    <a target="_blank" href="https://gitter.im/sef-global"
-                    class="btn btn-neutral btn-icon-only btn-gitter btn-round btn-lg" data-toggle="tooltip"
-                    data-original-title="Talk with us">
-                    <i class="fab fa-gitter"></i>
-                </a>
+                    
                 </div>
             </div>
             <div id="star-note"></div>


### PR DESCRIPTION
## Purpose
Do not maintain the Gitter channel anymore
The purpose of this PR is to fix #937

## Goals
Remove Gitter icon from the footer.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
![Screenshot#937](https://user-images.githubusercontent.com/77311602/116685320-c4340500-a9cf-11eb-93a1-179d4233f42d.JPG)
.
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-938-sef-site.surge.sh/

##  Checklist
- [X] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [X] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
