### PR TITLE
add link to the cards of the 2020 & 2019 to be clickable

### DIFF
--- a/scholarx/archive/index.html
+++ b/scholarx/archive/index.html
@@ -89,6 +89,7 @@
             </div>
         </div>
         <div class="row">
+            <a href="2020">
             <div class="col-md-6">
                 <img class="card-img card-template"
                      src="images/card-image.jpg">
@@ -102,6 +103,8 @@
                     </div>
                 </div>
             </div>
+            </a>
+            <a href="2019">
             <div class="col-md-6">
                 <img class="card-img card-template"
                      src="images/card-image.jpg">
@@ -115,6 +118,7 @@
                     </div>
                 </div>
             </div>
+            </a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Purpose
Make the archive cards of scholarx clickable #943

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
the probleme being easy, the fix is just basic a href link wrapping the cards, the same link used fr the view more link

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-{PR_NUMBER}-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
