### PR TITLE
Add link to the cards of the archive and set to clickable

### DIFF
--- a/assets/css/global-custom.css
+++ b/assets/css/global-custom.css
@@ -570,6 +570,18 @@ body{
     font-weight: bold;
 }
 
+/*Archive card section*/
+.archive-card
+{
+    border-radius: 1.5rem;
+    padding: 0px;
+}
+
+.rounded-top25px
+{
+    border-radius: 25px 25px 0px 0px;
+}
+
 .stats {
     font-size: 13px;
 }

--- a/scholarx/archive/index.html
+++ b/scholarx/archive/index.html
@@ -88,33 +88,25 @@
                 <p class="display-3 text-onelive font-weight-bolder">ScholarX</p>
             </div>
         </div>
-        <div class="row">
-            <div class="col-md-6">
-                <img class="card-img card-template"
-                     src="images/card-image.jpg">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">ScholarX 2020</h5>
-                        <p class="card-text">We expanded the programme to 18 mentors and over 50 mentees.
-                            Our mentors were once again from Fortune500 companies and top Universities.</p>
-                        <a href="2020"
-                           class="card-link">View More</a>
-                    </div>
+        <div class="card-deck">
+            <a href="2020" class="card col-md-6 shadow archive-card">
+                <img src="images/card-image.jpg" class="card-img card-template rounded-top25px" alt="2020">
+                <div class="card-body">
+                    <h5 class="card-title">ScholarX 2020</h5>
+                    <p class="card-text text-darker">We expanded the programme to 18 mentors and over 50 mentees.
+                        Our mentors were once again from Fortune500 companies and top Universities.
+                    </p>
                 </div>
-            </div>
-            <div class="col-md-6">
-                <img class="card-img card-template"
-                     src="images/card-image.jpg">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">ScholarX 2019</h5>
-                        <p class="card-text">For the 2019 cohort, we had 6 exceptional mentors based in the UK, US,
-                            Canada and Australia who generously volunteered their time.</p>
-                        <a href="2019"
-                           class="card-link">View More</a>
-                    </div>
+            </a>
+            <a href="2019" class="card col-md-6 shadow archive-card">
+                <img src="images/card-image.jpg" class="card-img card-template rounded-top25px" alt="2019">
+                <div class="card-body">
+                    <h5 class="card-title">ScholarX 2019</h5>
+                    <p class="card-text text-darker">For the 2019 cohort, we had 6 exceptional mentors based in the UK, US,
+                        Canada and Australia who generously volunteered their time.
+                    </p>
                 </div>
-            </div>
+            </a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Purpose
2019 and 2020 cards on the archive page, the cards are not clickable.
The purpose of this PR is to fix #943 

## Goals
Add links to the cards of the archive and set them to clickable.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot#943](https://user-images.githubusercontent.com/77311602/117699478-852d5d00-b1e2-11eb-8d36-c8ceb4b16ef8.JPG)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-945-sef-site.surge.sh/

##  Checklist
- [X] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [X] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Tested on chrome.

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
