### PR TITLE
Add show less button to Onelive page

### DIFF
--- a/onelive/functions.js
+++ b/onelive/functions.js
@@ -79,15 +79,23 @@ function loadProfiles() {
             if (data.length >= 8) {
                 let partOne = data.slice(0, 8);
                 let partTwo = data.slice(8);
+
                 // Mustache render - part one
                 let contentPartOne = Mustache.render($("#templateTeam").html(), {"data": partOne});
                 // Display first 8 profiles
                 $("#teamContent").html(contentPartOne);
                 // Hide button after displaying content part two
+                $("#btnShowLess").hide();
                 $("#btnShowMore").click(function () {
                     let contentPartTwo = Mustache.render($("#templateTeam").html(), {"data": partTwo});
                     $(contentPartTwo).appendTo("#teamContent").hide().fadeIn(1000);
                     $("#btnShowMore").hide();
+                    $("#btnShowLess").show();
+                });
+                $("#btnShowLess").click(function () {
+                    $("#teamContent").html(contentPartOne);
+                    $("#btnShowMore").show();
+                    $("#btnShowLess").hide();
                 });
             } else {
                 // Mustache render
@@ -96,6 +104,7 @@ function loadProfiles() {
                 $("#teamContent").html(content);
                 // Hide button because there are only 8 profiles to show
                 $("#btnShowMore").hide();
+                $("#btnShowLess").hide();
             }
         }
     });

--- a/onelive/index.html
+++ b/onelive/index.html
@@ -99,6 +99,7 @@
                 <div id="teamContent"></div>
 
                 <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
+                <button id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</button>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #947

## Goals
To add a "SEE LESS" button to the speakers' section

## Approach
Created a new "SEE LESS" button to contract back the speakers' section


### Screenshots
![Screenshot from 2021-05-27 19-34-57](https://user-images.githubusercontent.com/63200586/119841043-1d397f00-bf23-11eb-826a-33e54a3619c2.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{948}" with your PR number. -->
https://pr-{948}-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
