### PR TITLE
Set team members' LinkedIn profiles preview in a new tab.

### DIFF
--- a/team.html
+++ b/team.html
@@ -139,7 +139,8 @@
                         >
                     </a>
                     <div class="imgIcon">
-                        <a href="https://www.linkedin.com/in/{{linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
+                        <a href="https://www.linkedin.com/in/{{linkedin}}" target="_blank"
+                            class="btn btn-default btn-icon-only rounded-circle">
                             <i class="fab fa-linkedin"></i>
                         </a>
                     </div>

--- a/team.html
+++ b/team.html
@@ -133,7 +133,7 @@
             <div class="px-4">
                 <div class="hover-profile-card">
                     {{#social}}
-                    <a href="https://www.linkedin.com/in/{{linkedin}}">
+                    <a href="https://www.linkedin.com/in/{{linkedin}}" target="_blank">
                         <img src="assets/img/profiles/{{image}}"
                              class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                         >


### PR DESCRIPTION
## Purpose
The issue is related to the team members' LinkedIn profiles load in the same tab.


## Goals
Create team members' LinkedIn profiles direct to a new tab.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
![Screenshot (56)_LI](https://user-images.githubusercontent.com/77311602/121055872-45569700-c7db-11eb-819c-580afd9c1fd7.jpg)

### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-964-sef-site.surge.sh/

##  Checklist
- [X] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [X] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->
Crome 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
