### PR TITLE
Link SEF youtube channel to the footer

### DIFF
--- a/assets/content/static/footer.html
+++ b/assets/content/static/footer.html
@@ -32,6 +32,11 @@
                         data-original-title="Contribute us">
                         <i class="fab fa-github"></i>
                     </a>
+                    <a target="_blank" href="https://www.youtube.com/channel/UClw7QbeW_FOJz_fDMvjXsJw"
+                       class="btn btn-neutral btn-icon-only btn-youtube btn-round btn-lg" data-toggle="tooltip"
+                       data-original-title="Subscribe us">
+                        <i class="fab fa-youtube"></i>
+                    </a>
                     
                 </div>
             </div>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #972

## Goals
Link the SEF youtube channel to the footer

## Approach
Linked the SEF youtube channel to the footer 

### Screenshots
![Screenshot from 2021-06-22 14-38-40](https://user-images.githubusercontent.com/63200586/122897401-9af87b00-d367-11eb-9bb3-09b08530b589.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-973-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

