### PR TITLE
Feature fix background

### DIFF
--- a/scholarx/2021/featured-stories.json
+++ b/scholarx/2021/featured-stories.json
@@ -1,9 +1,9 @@
 [
   {
     "title": "ScholarX Class of 2019 | SX19",
-    "url": "https://blog.sefglobal.org/2019/11/scholarx-class-of-2019-sx19/",
+    "url": "https://sefglobal.medium.com/scholarx-class-of-2019-f69ac1c28077",
     "image": "sx-class-2019.jpeg",
-    "readingTime": "10",
+    "readingTime": "5",
     "author": {
       "name": "SEF Blog",
       "image": "sef-avatar.png"

--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -535,10 +535,10 @@
 </section>
 
 <section class="section past-section">
-    <div id="past-onelives" class="container">
+    <div id="past-onelives" class="container bg-white">
         <div class="row justify-content-center">
             <div class="col-9 text-center">
-                <h1 class="mb-0 text-onelive">Take a look at our past</h1>
+                <h1 class="mb-0 text-onelive ">Take a look at our past</h1>
                 <p class="display-3 text-onelive font-weight-bolder">ScholarX</p>
             </div>
         </div>

--- a/scholarx/2021/styles.css
+++ b/scholarx/2021/styles.css
@@ -119,3 +119,7 @@
 {
     color: #fbc53b;
 }
+
+#past-onelives{
+    background-color: white;
+}

--- a/scholarx/2021/styles.css
+++ b/scholarx/2021/styles.css
@@ -120,6 +120,6 @@
     color: #fbc53b;
 }
 
-#past-onelives{
+.bg-white{
     background-color: white;
 }

--- a/scholarx/archive/2020/featured-stories.json
+++ b/scholarx/archive/2020/featured-stories.json
@@ -1,9 +1,9 @@
 [
   {
     "title": "ScholarX Class of 2019 | SX19",
-    "url": "https://blog.sefglobal.org/2019/11/scholarx-class-of-2019-sx19/",
+    "url": "https://sefglobal.medium.com/scholarx-class-of-2019-f69ac1c28077",
     "image": "sx-class-2019.jpeg",
-    "readingTime": "10",
+    "readingTime": "5",
     "author": {
       "name": "SEF Blog",
       "image": "sef-avatar.png"


### PR DESCRIPTION
## Purpose
 The 'Take a look at our past ScholarX' has the same background as the previous sectionfix #970 

## Goals
Chnage background color to be able to see as a separate section.

## Approach
CSS background color added.

### Screenshots
No screenshot available
  
### Preview Link
https://pr-975-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
No related PR

## Test environment
Windows
