### PR TITLE
Remove Gitter chat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![HitCount](http://hits.dwyl.com/sef-global/sef-site.svg)](http://hits.dwyl.io/sef-global/sef-site)
 [![version](https://img.shields.io/badge/version-3.0.0-yellow.svg)](https://semver.org)
 [![Build Status](https://travis-ci.org/sef-global/sef-site.svg?branch=master)](https://travis-ci.org/sef-global/sef-site)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sef-global/community)
 [![Twitter Follow](https://img.shields.io/twitter/follow/goasksef.svg?style=social&label=Follow&maxAge=2592000?style=flat-square)](https://twitter.com/goasksef)
 
 This website was built by a set of enthusiastic developers as part of the Sustainable Education Foundation.


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #978

## Goals
To remove the Gitter Join chat badge on the README.md file

## Approach
Removed the Gitter Join chat badge on the README.md file

### Screenshots
![Screenshot from 2021-06-27 12-39-47](https://user-images.githubusercontent.com/63200586/123535901-d5399200-d744-11eb-8edd-16dcd12214bf.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-980-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

