### PR TITLE
Change the profiles section of ScholarX, Onelive and IRC pages

### DIFF
--- a/irc.html
+++ b/irc.html
@@ -61,13 +61,13 @@
 </section>
 
 <section class="section pb-0 bg-secondary">
-    <div class="container">
+    <div id="researchers" class="container">
         <h1 class="display-3 text-center mb-5">Researchers</h1>
         <!--Profile cards goes here-->
         <div id="teamContent"></div>
         <div class="row justify-content-center">
             <button id="btnShowMore" class="btn btn-link btn-outline-secondary btn-info mb-3">SEE MORE</button>
-            <button id="btnShowLess" class="btn btn-link btn-outline-secondary btn-info mb-3">SEE LESS</button>
+            <a href="#researchers" id="btnShowLess" class="btn btn-link btn-outline-secondary btn-info mb-3">SEE LESS</a>
         </div>
     </div>
 </section>

--- a/onelive/index.html
+++ b/onelive/index.html
@@ -88,7 +88,7 @@
     </section>
 
     <section class="section pb-0 bg-gradient-white">
-        <div class="container">
+        <div id="speakers" class="container">
             <div class="row justify-content-center">
                 <div class="col-9 text-center">
                     <h1 class="display-3 text-center mb-5">Speakers</h1>
@@ -99,7 +99,7 @@
                 <div id="teamContent"></div>
 
                 <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
-                <button id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</button>
+                <a href="#speakers" id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</a>
             </div>
         </div>
     </section>

--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -116,7 +116,7 @@
 
 
 <section class="section pb-0 bg-gradient-white">
-    <div class="container">
+    <div id="mentors" class="container">
         <h1 class="display-3 text-center mb-5">Mentors</h1>
         <div class="d-flex-wrap mb-5 justify-content-center">
             <button class="btn active mb-3" onclick="filterProfiles('all')"> Show all</button>
@@ -132,7 +132,7 @@
         <div id="teamContent"></div>
         <div class="row justify-content-center">
             <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
-            <button id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</button>
+            <a href="#mentors" id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
This PR fixes #976 
The three provided links all contain profiles sections with a "SEE LESS" button. Once the button is clicked the page does not scroll up to the former profile section view, instead it remains at the lower end of the page in the "Frequently Asked Questions" section(or lower), which removes the profiles section from view. A functionality had to be implemented in-order for the profiles section to scroll back to it's original position once the "SEE LESS' button is clicked.

OneLive - [https://sefglobal.org/onelive/](url)
ScholarX - [https://sefglobal.org/scholarx/2021/](url)
International Research Council - [https://sefglobal.org/irc.html](url)

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Adding an ID to the div section of each profile section, and assigning a hyperlink reference tag to the "SEE LESS" button will solve this issue. 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
*Find profile div sections in OneLive, ScholarX and IRC pages respectively. 
*Assign ID's to each profile div section.
*Change the "SEE LESS" `button` tag to `a` tag in each page.
*Add `href` tags and reference the ids of the profile div sections respectively. 

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
**Original profiles section after expansion :** 

![original_expanded](https://user-images.githubusercontent.com/49517852/123550715-831c5f00-d78c-11eb-99b0-58f2ea1f9811.PNG)

**Original profiles section after contraction :**

![original_contracted](https://user-images.githubusercontent.com/49517852/123550717-84e62280-d78c-11eb-8bca-1a4bcfc1e0cb.PNG)

**New profiles section after contraction(Scrolls back to original view):**

![new_contracted](https://user-images.githubusercontent.com/49517852/123550737-9f200080-d78c-11eb-80f0-b1e18e376d6c.PNG)

### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-983-sef-site.surge.sh/

##  Checklist
- This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
none

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
**OS :**
Edition	Windows 10 Home
Version	20H2
Installed on	‎5/‎3/‎2021
OS build	19042.1052
Experience	Windows Feature Experience Pack 120.2212.2020.0

**Java:**
java 14.0.1 2020-04-14
Java(TM) SE Runtime Environment (build 14.0.1+7)
Java HotSpot(TM) 64-Bit Server VM (build 14.0.1+7, mixed mode, sharing)

**Browser:**
Google Chrome
Version 91.0.4472.114 (Official Build) (64-bit)


## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
none
