### PR TITLE
Replace SEF gitter Channel with SEF Slack channel 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ channels (wikipedia, stackoverflow) but also do not hesitate to ask questions to
 
 ## Communication Channels
 
-Currently, we use Gitter as our communication channel. [Join SEF Gitter Chanel](https://gitter.im/sef-global)
+Currently, we use Slack as our communication channel. [Join SEF Slack Channel](http://sefheadquarters.slack.com)
 
 ## Private and Public Chat or Issue Tracker
 


### PR DESCRIPTION
## Purpose
To lead developers into the active community platform. #986 

## Goals
Replacing the SEF Gitter  link with SEF slack link to lead people to active slack channel.

## Approach
made changes in the CONTRIBUTING.md file

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  


##  Checklist
- [X] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [X] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation






