### PR TITLE
Migrate PR-Preview generator to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+# This is the work flow to generate preview links for Pull Requests
+name: PR-Preview-Generator
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Using Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Installing Surge
+        run: npm i -g surge
+      - name: Deploying on Surge
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+          DEPLOY_DOMAIN: https://pr-${{ github.event.number }}-sef-site.surge.sh
+        run: surge ./ $DEPLOY_DOMAIN --token $SURGE_TOKEN


### PR DESCRIPTION
## Purpose
Migrate PR-Preview Generator to GitHub Actions from Travis-ci.org
The purpose of this PR is to fix #982 

## Goals
Fix the PR-Preview Generator
  
### Preview Link
https://pr-988-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
Ubuntu 20.04