### PR TITLE
Replace IRC intern's images with Cloudinary URLs

### DIFF
--- a/irc.html
+++ b/irc.html
@@ -379,7 +379,7 @@
         {{#data}}
           <tr onclick="window.location='{{linkedin}}';">
             <th scope="row">
-                <img src="assets/img/irc/irc-interns/{{image}}" class="avatar">
+                <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/{{image}}" class="avatar">
             </th>
                 <td>{{name}}</td>
                 <td>{{university}}</td>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #997

## Goals
To replace the image column in the google sheet with Cloudinary image links & to change the image URL in the irc.html file 

## Approach
* Replaced the google sheet with new links
* Replaced the Image URL in the irc.html file 

### Screenshots
![Screenshot from 2021-07-05 13-53-34](https://user-images.githubusercontent.com/63200586/124440650-743f3900-dd98-11eb-83b6-82be3a6e0ddd.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-999-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

