### PR TITLE
Replace onelive speaker's images with Cloudinary URLs

### DIFF
--- a/onelive/index.html
+++ b/onelive/index.html
@@ -261,7 +261,7 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="/assets/img/profiles/{{image}}"
+                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/{{image}}"
                          class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
                     <div class="imgIcon">


### PR DESCRIPTION
## Purpose

The purpose of this PR is to fix #994

## Goals
To replace the image column in the google sheet with Cloudinary image links & to change the image URL in the Onelive/index.html file

## Approach
* Replaced the google sheet with new links
* Replaced the Image URL in the Onelive/index.html file

### Screenshots
![Screenshot from 2021-07-07 10-02-03](https://user-images.githubusercontent.com/63200586/124700475-70332880-df0a-11eb-8130-80778a89b740.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1003-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

