### PR TITLE
Add scale to Onelive speaker's images

### DIFF
--- a/onelive/index.html
+++ b/onelive/index.html
@@ -261,7 +261,7 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/{{image}}"
+                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
                          class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
                     <div class="imgIcon">


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1011

## Goals
To replace the image link with scale parameters

## Approach
Replaced the new link with scale parameters


### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1012-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

