### PR TITLE
Replace ScholarX 2020 mentor's images with Cloudinary URLs

### DIFF
--- a/scholarx/archive/2020/index.html
+++ b/scholarx/archive/2020/index.html
@@ -205,7 +205,7 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card" onclick="openMentorProfile('{{index}}')">
-                    <img src="images/{{image}}"
+                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
                          class="rounded-circle img img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
                 </div>


### PR DESCRIPTION
## Purpose
Replace ScholarX 2020 mentor's images with Cloudinary URLs #1037

## Goals
Replace ScholarX 2020 mentor's images with Cloudinary URLs

## Approach
Copy image URLs in issue #1037 to spreadsheet and update link in index.html

### Screenshots
![Screenshot (192)](https://user-images.githubusercontent.com/83522139/126602624-0bcce1d5-76e4-4317-a2c9-04e659ca2d0b.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1041-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
