### PR TITLE
Replace ScholarX 2021 mentor's images with Cloudinary URLs 

### DIFF
--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -599,7 +599,7 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card" onclick="openMentorProfile('{{index}}')">
-                    <img src="images/{{image}}"
+                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
                          class="rounded-circle img img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
                 </div>

--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -27,7 +27,7 @@
     <!-- Icons -->
     <link href="/assets/vendor/nucleo/css/nucleo.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" rel="stylesheet">
-    <!-- Argon CSS -->
+    <!-- Argon CSS --> 
     <link type="text/css" href="/assets/css/argon.css?v=1.0.1" rel="stylesheet">
     <!-- global CSS -->
     <link type="text/css" href="/assets/css/global-custom.css" rel="stylesheet">


### PR DESCRIPTION
## Purpose
fix  #1036

## Goals
Replace ScholarX 2021 mentor's images with Cloudinary URLs 

## Approach
Copy image URLs in issue #1036  to spreadsheet and update link in index.html

### Screenshots
![Screenshot (193)](https://user-images.githubusercontent.com/83522139/126603790-c8a372ff-816e-4413-b008-43ce431af24d.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1042-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
#1041 
## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
