### PR TITLE
Replace ScholarX 2020 mentee's images with Cloudinary URLs

### DIFF
--- a/scholarx/archive/2020/index.html
+++ b/scholarx/archive/2020/index.html
@@ -292,7 +292,7 @@
     {{#data}}
         <tr onclick="window.location='{{linkedin}}';">
             <th scope="row">
-                <img src="images/mentees/{{image}}" class="avatar">
+                <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_48,w_48/{{image}}" class="avatar">
             </th>
                 <td>{{name}}</td>
                 <td>{{university}}</td>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1044

## Goals
To replace the image column in the google sheet with Cloudinary image links & to change the link in the HTML file 

## Approach
Added new links to the google sheet and changed the link in the HTML file

### Screenshots
![Screenshot from 2021-07-23 11-43-40](https://user-images.githubusercontent.com/63200586/126743848-a236c5ba-52ef-4a20-bd6b-ec1979dd0b0e.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1046-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


