### PR TITLE
Replace ScholarX 2019 mentees images with Cloudinary URLs

### DIFF
--- a/scholarx/archive/2019/index.html
+++ b/scholarx/archive/2019/index.html
@@ -149,7 +149,7 @@
         {{#data}}
           <tr onclick="window.location='{{linkedin}}';">
             <th scope="row">
-                <img src="images/mentees/{{image}}" class="avatar">
+                <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_48,w_48/{{image}}" class="avatar">
             </th>
                 <td>{{name}}</td>
                 <td>{{university}}</td>

--- a/scholarx/archive/2019/index.html
+++ b/scholarx/archive/2019/index.html
@@ -114,7 +114,7 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="images/{{image}}"
+                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
                          class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
                     >
                     <div class="imgIcon">


### PR DESCRIPTION
## Purpose
Replace ScholarX 2019 mentor's images with Cloudinary URLs fix #1047 

## Goals
Replace ScholarX 2019 mentor's images with Cloudinary URLs

## Approach
Copy image URLs in issue #1047  to spreadsheet and update link in index.html

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1051-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
#1041
#1042
#1045

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
