### PR TITLE
Prevent showing 'SEE MORE/SEE LESS' buttons before loading the profiles on team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -44,7 +44,7 @@
         <!--Profile cards goes here-->
         <div id="advisoryPanel"></div>
 
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnAdvisoryPanel" style="visibility:hidden;">
             <button id="btnShowMore_advisoryPanel" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
         </div>
     </div>
@@ -57,7 +57,7 @@
         <!--Profile cards goes here-->
         <div id="externalCollaborators"></div>
 
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnExCollaborators" style="visibility:hidden;">
             <button id="btnShowMore_externalCollaborators" class="btn btn-link btn-outline-white btn-info">SEE MORE
             </button>
         </div>
@@ -71,7 +71,7 @@
         <!--Profile cards goes here-->
         <div id="executiveCommitee"></div>
 
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnExCommittee" style="visibility:hidden;">
             <button id="btnShowMore_executiveCommitee" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
             <a id="btnShowLess_executiveCommitee" class="btn btn-link btn-outline-white btn-info" href="#exec_com_div">SEE LESS</a>
         </div>
@@ -85,7 +85,7 @@
         <!--Profile cards goes here-->
         <div id="techTeam"></div>
 
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnDevTeam" style="visibility:hidden;">
             <button id="btnShowMore_techTeam" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
         </div>
     </div>
@@ -98,7 +98,7 @@
         <!--Profile cards goes here-->
         <div id="alumni"></div>
 
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnAlumni" style="visibility:hidden;">
             <button id="btnShowMore_alumni" class="btn btn-link btn-outline-white btn-info mb-3">SEE MORE</button>
             <a id="btnShowLess_alumni" class="btn btn-link btn-outline-white btn-info mb-3" href="#alum_div">SEE LESS</a>
         </div>
@@ -183,6 +183,12 @@
                 loadData("techTeam", techTeam);
                 loadData("designTeam", designTeam);
                 loadData("alumni", alumni);
+
+                document.getElementById('btnAdvisoryPanel').style.visibility = "visible";
+                document.getElementById('btnExCollaborators').style.visibility = "visible";
+                document.getElementById('btnExCommittee').style.visibility = "visible";
+                document.getElementById('btnDevTeam').style.visibility = "visible";
+                document.getElementById('btnAlumni').style.visibility = "visible";
 
             }
         });


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1056

## Goals
To fix the Responsiveness of the buttons on the team page

## Approach
Fixed the  Responsiveness of the buttons on the team page

### Screenshots
![Screenshot from 2021-07-30 18-12-43](https://user-images.githubusercontent.com/63200586/127654700-e3d5b0f1-b6a0-4bbc-b568-1927ae692d24.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1059-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

