### PR TITLE
Prevent showing 'SEE MORE/SEE LESS' buttons before loading profiles (Onelive & IRC)

### DIFF
--- a/irc.html
+++ b/irc.html
@@ -65,7 +65,7 @@
         <h1 class="display-3 text-center mb-5">Researchers</h1>
         <!--Profile cards goes here-->
         <div id="teamContent"></div>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnResearchers" style="visibility:hidden;">
             <button id="btnShowMore" class="btn btn-link btn-outline-secondary btn-info mb-3">SEE MORE</button>
             <a href="#researchers" id="btnShowLess" class="btn btn-link btn-outline-secondary btn-info mb-3">SEE LESS</a>
         </div>
@@ -358,6 +358,7 @@
             dataType: 'json',
             success: function (data) {
                 let templateInterns = Mustache.render($("#templateInterns").html(), {"data": data});
+                document.getElementById('btnResearchers').style.visibility = "visible";
                 //display interns
                 $("#internContent").html(templateInterns);
             }

--- a/onelive/functions.js
+++ b/onelive/functions.js
@@ -106,6 +106,7 @@ function loadProfiles() {
                 $("#btnShowMore").hide();
                 $("#btnShowLess").hide();
             }
+            document.getElementById('btnSpeakers').style.visibility = "visible";
         }
     });
 }

--- a/onelive/index.html
+++ b/onelive/index.html
@@ -94,7 +94,7 @@
                     <h1 class="display-3 text-center mb-5">Speakers</h1>
                 </div>
             </div>
-            <div class="row justify-content-center">
+            <div class="row justify-content-center" id="btnSpeakers" style="visibility:hidden;">
                 <!--Profile cards goes here-->
                 <div id="teamContent"></div>
 


### PR DESCRIPTION

## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1063

## Goals
To show  the "SEE MORE/SEE LESS" buttons after loading the profiles

## Approach
Prevented showing buttons before loading the profiles

### Screenshots
![Screenshot from 2021-08-03 10-27-00](https://user-images.githubusercontent.com/63200586/127960160-84f50cd3-1c11-45ff-b6cc-710162ce0e98.png)
![Screenshot from 2021-08-03 10-27-37](https://user-images.githubusercontent.com/63200586/127960163-e1f80f41-86e1-4687-9c07-6124226fdb06.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1066-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

