### PR TITLE
Make Onelive speakers LinkedIn profiles load in new tab.

### DIFF
--- a/onelive/index.html
+++ b/onelive/index.html
@@ -261,11 +261,13 @@
         <div class="col-md-3 col-lg-3 mb-5">
             <div class="px-4">
                 <div class="hover-profile-card">
-                    <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
-                         class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
-                    >
+                    <a href="{{linkedin}}" target="_blank">
+                        <img src="https://res.cloudinary.com/dsxobn1ln/image/upload/c_scale,h_150,w_150/{{image}}"
+                            class="rounded-circle img-center img-fluid shadow shadow-lg--hover imgHover"
+                        >
+                    </a>
                     <div class="imgIcon">
-                        <a href="{{linkedin}}" class="btn btn-default btn-icon-only rounded-circle">
+                        <a href="{{linkedin}}" target="_blank" class="btn btn-default btn-icon-only rounded-circle">
                             <i class="fab fa-linkedin"></i>
                         </a>
                     </div>


### PR DESCRIPTION
## Purpose
Onelive speaker LinkedIn profiles are loading in the same tab
The purpose of this PR is to fix #1064

## Goals
Make Onelive speaker LinkedIn profiles load in a new tab.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
![1064](https://user-images.githubusercontent.com/77311602/128031397-92aed9ff-ce0c-4c94-84c4-bc2d46a2dcab.gif)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1067-sef-site.surge.sh/

##  Checklist
- [X] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [X] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
Ubuntu 20.04
Google Chrome

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
