### PR TITLE
ScholarX page background color fix

### DIFF
--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -534,8 +534,8 @@
     </div>
 </section>
 
-<section class="section past-section">
-    <div id="past-onelives" class="container">
+<section class="section">
+    <div id="past-onelives" class="bg-white">
         <div class="row justify-content-center">
             <div class="col-9 text-center">
                 <h1 class="mb-0 text-onelive">Take a look at our past</h1>


### PR DESCRIPTION
## Purpose
this PR is to fix #970 

## Goals
In the ScholarX-21 page, the Take a look at our past ScholarX has the same background as the previous section. Therefore that section is not getting highlighted and it wont see as a separate section.

## Approach
changed the class of the container to class="bg-white"

### Screenshots
![Screenshot (241)](https://user-images.githubusercontent.com/83522139/128126579-b7167c22-0879-4e9b-9210-338043df3dd0.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1069-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
 #975

## Test environment
npm

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
