### PR TITLE
Prevent showing 'SEE MORE/SEE LESS' buttons before loading profiles on ScholarX pages

### DIFF
--- a/scholarx/2021/functions.js
+++ b/scholarx/2021/functions.js
@@ -74,6 +74,7 @@ function loadProfiles() {
             mentorProfiles = profiles;
             filteredProfiles = profiles;
             sliceProfiles(profiles);
+            document.getElementById('btnMentors').style.visibility = "visible";
         }
     });
 }
@@ -101,7 +102,7 @@ function loadFeaturedStories() {
         url: 'https://script.google.com/macros/s/AKfycbzpNJgeah9hpaf4mRWer5U_y27qWdeFArS6j17LhtxxhAKXkg0uaU9iKG5JHmM1RGP_/exec',
         dataType: 'json',
         success: function (data) {
-
+            document.getElementById('btnFeaturedStories').style.visibility = "visible";
             //slice array to two parts
             if (data.length >= 6) {
                 let partOne = data.slice(0, 6);

--- a/scholarx/2021/index.html
+++ b/scholarx/2021/index.html
@@ -130,7 +130,7 @@
         </div>
         <!-- Profile cards goes here -->
         <div id="teamContent"></div>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnMentors" style="visibility:hidden;">
             <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
             <a href="#mentors" id="btnShowLess" class="btn btn-link btn-outline-white btn-info">SEE LESS</a>
         </div>
@@ -144,7 +144,7 @@
         <h1 class="display-3 text-center mb-5">Featured Stories</h1>
         <!--Featured stories goes here-->
         <div id="featured-stories" class="featured-stories"></div>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnFeaturedStories" style="visibility:hidden;">
             <button id="btn-featured-stories-show-more" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
         </div>
     </div>

--- a/scholarx/archive/2019/index.html
+++ b/scholarx/archive/2019/index.html
@@ -64,7 +64,7 @@
 <section class="section pb-0 bg-gradient-white">
     <div class="container">
         <h1 class="display-3 text-center mb-5">Mentors</h1>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnMentors" style="visibility:hidden;">
             <!--Profile cards goes here-->
             <div id="teamContent"></div>
 
@@ -177,7 +177,7 @@
             url: 'https://script.google.com/macros/s/AKfycbyIXVj_cpckzkl7xN-C7W7wlW7dG2fAwHaYNhgrsqf_E4tySxIXJRifUpX4s5eQPKjo/exec',
             dataType: 'json',
             success: function (data) {
-
+                document.getElementById('btnMentors').style.visibility = "visible";
                 //slice array to two parts
                 if (data.length >= 8) {
                     let partOne = data.slice(0, 8);

--- a/scholarx/archive/2020/functions.js
+++ b/scholarx/archive/2020/functions.js
@@ -36,6 +36,7 @@ function loadProfiles() {
         dataType: 'json',
         success: function (profiles) {
             mentorProfiles = profiles;
+            document.getElementById('btnMentors').style.visibility = "visible";
             // Add a new key named `index` with the index (To use with moustache template)
             profiles.forEach(function (profile, index) {
                 profile.index = index;
@@ -86,7 +87,7 @@ function loadFeaturedStories() {
         url: 'https://script.google.com/macros/s/AKfycbyrED1ynzfadBwuHgy1Gl7DH35yuY9rtBGe-VJ2wGgyiB-o-cVbQyXFQNEkdyByRJpgKA/exec',
         dataType: 'json',
         success: function (data) {
-
+            document.getElementById('btnFeaturedStories').style.visibility = "visible";
             //slice array to two parts
             if (data.length >= 6) {
                 let partOne = data.slice(0, 6);

--- a/scholarx/archive/2020/index.html
+++ b/scholarx/archive/2020/index.html
@@ -115,7 +115,7 @@
       <h1 class="display-3 text-center mb-5">Mentors</h1>
         <!--Profile cards goes here-->
         <div id="teamContent"></div>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnMentors" style="visibility:hidden;">
             <button id="btnShowMore" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
             <a id="btnShowLess" class="btn btn-link btn-outline-white btn-info" href="#mentors_div">SEE LESS</a>
         </div>
@@ -149,7 +149,7 @@
         <h1 class="display-3 text-center mb-5">Featured Stories</h1>
         <!--Featured stories goes here-->
         <div id="featured-stories" class="featured-stories"></div>
-        <div class="row justify-content-center">
+        <div class="row justify-content-center" id="btnFeaturedStories" style="visibility:hidden;">
             <button id="btn-featured-stories-show-more" class="btn btn-link btn-outline-white btn-info">SEE MORE</button>
         </div>
     </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1070

## Goals
To show the "SEE MORE/SEE LESS" buttons after loading the profiles

## Approach
Prevented showing buttons before loading the profiles

### Screenshots
![Screenshot from 2021-08-05 12-20-38](https://user-images.githubusercontent.com/63200586/128305463-93a121fa-4d76-4a68-a03c-1a67de5187e2.png)
![Screenshot from 2021-08-05 12-20-45](https://user-images.githubusercontent.com/63200586/128305470-1dcbaff2-022b-461b-8410-dc89cc120f6d.png)
![Screenshot from 2021-08-05 12-21-00](https://user-images.githubusercontent.com/63200586/128305474-afc76aa4-dcd2-44c0-9dc8-39f9c7c1be41.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1072-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

