### PR TITLE
Add a preloader to the IRC research intern's section

### DIFF
--- a/assets/css/global-custom.css
+++ b/assets/css/global-custom.css
@@ -111,6 +111,7 @@ body {
 
 /*end of upspeak testimonial section*/
 /*Skeleton preloader section*/
+/*Skeleton profile cards*/
 .skeleton {
     display: flex;
     justify-content: center;
@@ -140,7 +141,23 @@ body {
 .skeleton .line-secondary {
     width: 150px;
 }
+/*End of Skeleton profile cards*/
+/*Skeleton Table*/
+.column-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    animation: pulse 2s infinite ease-in-out;
+}
 
+.column-content {
+    width: 75%;
+    height: 20px;
+    margin-top: 15px;
+    animation: pulse 2s infinite ease-in-out;
+}
+/*End of Skeleton Table*/
+/*Skeleton media queries*/
 @keyframes pulse {
     0% {
         background-color: #cad6e6;
@@ -168,8 +185,8 @@ body {
         height: 150px;
     }
 }
-
-/*End Skeleton section*/
+/*End of Skeleton media queries*/
+/*End of Skeleton section*/
 
 /* custom styling for testimonials section*/
 .testimonial .testimonial-photo {

--- a/irc.html
+++ b/irc.html
@@ -76,7 +76,63 @@
     <div class="container">
         <h1 class="display-3 text-center mb-5">Research Interns In 2020</h1>
         <!--Profile cards goes here-->
-        <div id="internContent"></div>
+        <div id="internContent">
+            <!-- Skeleton Profiles goes here -->
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Name</th>
+                    <th scope="col">University</th>
+                    <th scope="col">View Blog Article</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td>
+                        <div class="column-avatar"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="column-avatar"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div class="column-avatar"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                    <td>
+                        <div class="column-content"></div>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1091

## Goals
To add a skeleton table until the profiles are loaded

## Approach
Used a skeleton table for the intern's section

### Screenshots
![Screenshot from 2021-08-19 10-40-36](https://user-images.githubusercontent.com/63200586/130011236-2a653d40-d522-40a6-9853-2f9407942072.png)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1092-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

