### PR TITLE
Replace Scholarx21 link with the summer Scholarx21 link

### DIFF
--- a/scholarx/index.html
+++ b/scholarx/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167873271-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-167873271-1');
-  </script>
-  <meta http-equiv="Refresh" content="0; url=2021/" />
-</head>
-<body>
-<p>Redirecting you to <a href="2021/">the current ScholarX program</a>.</p>
-</body>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167873271-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'UA-167873271-1');
+    </script>
+    <meta http-equiv="Refresh" content="0; url=2021/summer" />
+  </head>
+  <body>
+    <p>Redirecting you to <a href="2021/summer/">the current ScholarX program</a>.</p>
+  </body>
 </html>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1096 
Users are redirected to old Scholarx 2021 page when clicking the related link in the project section.

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Edit the url to redirect users to the new Scholarx 2021 Summer page.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Edit the index.html file inside scholarx/ and replace any links from 2021/ to 2021/summer.
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1098-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
- Operating system: Linux
- Code Editor: VSCode
- Browsers: Firefox and Chrome

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
Simply going and scanning through the code to find the related url.