### PR TITLE
Developer badge image load fix

### DIFF
--- a/developers/functions.js
+++ b/developers/functions.js
@@ -10,7 +10,7 @@ $(function () {
             dataType: 'json',
             success: function (data) {
                 data.user.avatar_template =
-                    "https://sjc2.discourse-cdn.com/free1" + data.user.avatar_template.replace(/{size}/g, "60");
+                    "https://sea1.discourse-cdn.com/free1" + data.user.avatar_template.replace(/{size}/g, "60");
                 let templateProfile = Mustache.render($("#profile-template").html(), {"data": data});
                 $("#profile").html(templateProfile);
             },


### PR DESCRIPTION
### **Purpose**
fix #1107

### **Goals**
Developer badges page profile picture is not loading, the request for it receives a 404 status code. replace the URL so that it fetches and renders the image from sef hive

### **Approach**
Replace the URL in the function.js file with the image URL from the sef discourse avatars.

**### Preview Link**
https://pr-1110-sef-site.surge.sh/

### **Checklist**
- [x]  This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x]  I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation

Related PRs
none
### 
**Test environment**
Local

### **Learning**
JS functions