### PR TITLE
Add colored indicator to timeline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "liveServer.settings.port": 5501
-}

--- a/scholarx/2022/index.html
+++ b/scholarx/2022/index.html
@@ -100,7 +100,7 @@
                         <span>Community bonding</span>
                         <span class="float-right">15 May, 2022 - 28 May, 2022</span>
                     </li>
-                    <li>
+                    <li class="active">
                         <span>Official start date of ScholarX</span>
                         <span class="float-right">29 May, 2022</span>
                     </li>

--- a/scholarx/2022/styles.css
+++ b/scholarx/2022/styles.css
@@ -31,6 +31,10 @@
     z-index: 400;
 }
 
+.timeline > li.active:before{
+    background-color: #22c0e8;
+}
+
 .hover-profile-card .img {
     cursor: pointer;
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The timeline of the ScholarX page does not have an indicator to specify the current timeline date #1202 

## Goals
To add a colored indicator to the timeline of the page
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
Added color to the present timeline date of the ScholarX process
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->

### Screenshots
![image](https://user-images.githubusercontent.com/104125359/183271285-bfc80aac-bc4c-4ed5-b0a5-32012af2f0d5.png)
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-{PR_NUMBER}-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
