### PR TITLE
Add a loading skeleton to success stories page

### DIFF
--- a/success_stories/index.html
+++ b/success_stories/index.html
@@ -51,6 +51,106 @@
         <h1 class="display-3 text-center main-topic">ScholarX Success Stories</h1>
         <br>
         <div id="card_container">
+            <div class="row story-box shadow">
+                <div class="col-md-12">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <div class="mentee col">
+                                <div class="row mentee-details">
+            
+                                    <div class="mentee-profile-pic">
+                                        <img class="img skeleton-storycard-common">
+                                    </div>
+                                    <h5 class="name skeleton-storycard-common skeleton-storycard-text"><a href="#" target=”_blank”></a></h5>
+                                    <p class="details skeleton-storycard-common skeleton-storycard-text"></p>
+            
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-9">
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                        </div>
+                    </div>
+            
+                    <p class="paragraph text-justify skeleton-storycard-common skeleton-storycard-text"></p>
+                    <p class="paragraph text-justify skeleton-storycard-common skeleton-storycard-text"></p>
+                    <ul>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                    </ul>
+                    <hr>
+                    <div class="row details-box">
+                        <div class="mentor col">
+                            <h5 class="mentor-details-title skeleton-storycard-common skeleton-storycard-text-short"></h5>
+                            <div class="row mentor-details">
+                                <div>
+                                    <div class="mentor-profile-pic">
+                                        <img class="img skeleton-storycard-common">
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="name skeleton-storycard-common skeleton-storycard-text-details"><a href="#" target=”_blank”></a></p>
+                                    <p class="details skeleton-storycard-common skeleton-storycard-text-details"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row story-box shadow">
+                <div class="col-md-12">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <div class="mentee col">
+                                <div class="row mentee-details">
+            
+                                    <div class="mentee-profile-pic">
+                                        <img class="img skeleton-storycard-common">
+                                    </div>
+                                    <h5 class="name skeleton-storycard-common skeleton-storycard-text"><a href="#"
+                                            target=”_blank”></a></h5>
+                                    <p class="details skeleton-storycard-common skeleton-storycard-text"></p>
+            
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-9">
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                            <div class="paragraph skeleton-storycard-common skeleton-storycard-text-highlight"></div>
+                        </div>
+                    </div>
+            
+                    <p class="paragraph text-justify skeleton-storycard-common skeleton-storycard-text"></p>
+                    <p class="paragraph text-justify skeleton-storycard-common skeleton-storycard-text"></p>
+                    <ul>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                        <p class="paragraph skeleton-storycard-common skeleton-storycard-text"></p>
+                    </ul>
+                    <hr>
+                    <div class="row details-box">
+                        <div class="mentor col">
+                            <h5 class="mentor-details-title skeleton-storycard-common skeleton-storycard-text-short"></h5>
+                            <div class="row mentor-details">
+                                <div>
+                                    <div class="mentor-profile-pic">
+                                        <img class="img skeleton-storycard-common">
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="name skeleton-storycard-common skeleton-storycard-text-details"><a href="#"
+                                            target=”_blank”></a></p>
+                                    <p class="details skeleton-storycard-common skeleton-storycard-text-details"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </section>

--- a/success_stories/styles.css
+++ b/success_stories/styles.css
@@ -105,9 +105,8 @@ hr {
     border-radius: 50% !important;
     width: 100px;
     height: 100px;
-    padding: 5px;
     border-radius: 50%;
-    background-color: #EAECEE;
+    border: 5px solid #EAECEE;
 }
 
 /* ----------------------------mentor ------------------------- */
@@ -154,11 +153,58 @@ hr {
     width: 50px;
     height: 50px;
     margin-left: -15px;
-    padding: 5px;
+    border: 5px solid #EAECEE;
     border-radius: 50%;
-    background-color: #EAECEE;
 }
 
 .mentor {
     margin-left: 0px;
+}
+
+/* --------------------- skeleton loading ----------------------------- */
+.skeleton-storycard-common {
+    opacity: .7;
+    animation: skeleton-card-loading 1s linear infinite alternate;
+
+}
+
+@keyframes skeleton-card-loading {
+    0%{
+        background-color: hsl(210, 11%, 85%);
+    }
+
+    100%{
+        background-color: hsl(210, 11%, 93%);
+    }
+}
+
+.skeleton-storycard-text, .skeleton-storycard-text-short, 
+.skeleton-storycard-text-highlight, .skeleton-storycard-text-details {
+    margin-bottom: 0.5rem;
+    border-radius: 0.25rem;
+}
+
+.skeleton-storycard-text {
+    width: 100%;
+    height: 1rem;
+}
+
+.skeleton-storycard-text-short {
+    width: 20%;
+    height: 1rem;
+}
+
+.skeleton-storycard-text-highlight {
+    height: 1.5rem;
+}
+
+.skeleton-storycard-text-details {
+    width: 50px;
+    height: 0.8rem;
+    margin-top: 10px;
+}
+
+.skeleton-storycard-text:last-child {
+    margin-bottom: 0;
+    width: 80%;
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1238 

## Goals
On the success stories page, It takes a few seconds to get the content through the API, render it using mustache and display it on the page. We can display some kind of animation until the content is rendered properly.

## Approach
Display a loading skeleton until the loading is completed.

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot 2022-10-03 at 12 29 19](https://user-images.githubusercontent.com/70215958/193518145-5f757681-9347-4289-96a7-30b3370902dc.jpg)

### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1249-sef-site.surge.sh/success_stories

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
macOS 12.6, Chrome Version 105.0.5195.125 (Official Build) (arm64)

