### PR TITLE
Update the Slack invitation link

### DIFF
--- a/assets/content/static/footer.html
+++ b/assets/content/static/footer.html
@@ -37,7 +37,7 @@
                        data-original-title="Subscribe us">
                         <i class="fab fa-youtube"></i>
                     </a>
-                    <a target="_blank" href="https://join.slack.com/t/sefheadquarters/shared_invite/zt-1ds9bjtli-ry~ggwf2kSJ_j5src89GBQ"
+                    <a target="_blank" href="https://join.slack.com/t/sefheadquarters/shared_invite/zt-1h5zt3go4-wnRDDpecbWiTdpDv1VUoVg"
                        class="btn btn-neutral btn-icon-only btn-slack btn-round btn-lg" data-toggle="tooltip"
                        data-original-title="Join us">
                         <i class="fab fa-slack"></i>

--- a/assets/content/static/navbar.html
+++ b/assets/content/static/navbar.html
@@ -127,7 +127,7 @@
                                         <h6 class="text-primary mb-md-1">Join the Team</h6>
                                     </div>
                                 </a>
-                                <a href="https://join.slack.com/t/sefheadquarters/shared_invite/zt-1ds9bjtli-ry~ggwf2kSJ_j5src89GBQ" class="media d-flex align-items-center">
+                                <a href="https://join.slack.com/t/sefheadquarters/shared_invite/zt-1h5zt3go4-wnRDDpecbWiTdpDv1VUoVg" class="media d-flex align-items-center">
                                     <div class="media-body ml-3">
                                         <h6 class="text-primary mb-md-1">Slack</h6>
                                     </div>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #1248 

## Goals
The current slack invitation link has expired. Therefore this PR will update it in both navbar and footer

## Approach
Replaced the slack invitation link in both navbar and footer with the following link: https://join.slack.com/t/sefheadquarters/shared_invite/zt-1h5zt3go4-wnRDDpecbWiTdpDv1VUoVg

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1251-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
macOS 12.6, Chrome Version 105.0.5195.125 (Official Build) (arm64)
