### PR TITLE
Fix ScholarX 2022 page alignment

### DIFF
--- a/scholarx/2022/index.html
+++ b/scholarx/2022/index.html
@@ -538,7 +538,7 @@
 </section>
 
 <section class="section">
-    <div id="past-onelives" class="bg-white">
+    <div id="past-onelives" class="bg-white container">
         <div class="row justify-content-center">
             <div class="col-9 text-center">
                 <h1 class="mb-0 text-onelive">Take a look at our past</h1>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #1274 

## Goals
The entire scholax 2022 page is not aligned center and has a small extra space on the right side of the page.

## Approach
Add missing container class to the archive section

### Screenshots
![Screenshot 2022-10-09 at 16 18 17](https://user-images.githubusercontent.com/70215958/194752562-7c8bc84d-80b3-4b65-8e2b-b10b955bcc41.jpg)
  
### Preview Link

https://pr-1277-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
macOS, Chrome Latest

