### PR TITLE
Fix thematic break styles

### DIFF
--- a/success-stories/styles.css
+++ b/success-stories/styles.css
@@ -1,4 +1,9 @@
 /* ---------------------- Additional styles ------------------------ */
+.story-box hr {
+    margin-top: 0px;
+    margin-bottom: 10px;
+}
+
 .story-section {
     padding: 10px 10px 10px 10px;
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1276

## Goals
The hr tag (thematic break) on the story card takes up so much space. So we need to reduce the margins.

## Approach
Reduce the margins only for the hr tags inside the story card.


### Screenshots
![image](https://user-images.githubusercontent.com/83972174/194754327-90a80971-6db9-4337-96bf-992cf9559e07.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1280-sef-site.surge.sh/success-stories

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Windows 10, Chrome latest

