### PR TITLE
Change the background color of the success-stories section of ScholarX 2022 page 

### DIFF
--- a/scholarx/2022/index.html
+++ b/scholarx/2022/index.html
@@ -121,12 +121,12 @@
 
 <!-- success stories section -->
 <section class="section"
-    style="display: flex; align-items: center; justify-content: center; padding-bottom: 130px;">
+    style="display: flex; align-items: center; justify-content: center; background-color: #f4f5f7;">
     <div class="container row">
         <div class="pr-md-5 col-md-6" style="display: flex; justify-content: center; padding:0rem 0rem">
             <img src="./images/success.png" alt="success illustration" style="height : 285px; ">
         </div>
-        <div id="past-onelives" class="bg-white col-md-6 pl-md-3" style="padding:0rem 0rem; display: flex; flex-direction: column; justify-content: center;">
+        <div id="past-onelives" class="col-md-6 pl-md-3" style="padding:0rem 0rem; display: flex; flex-direction: column; justify-content: center;">
             <div class="row justify-content-center">
                 <div class="col-11 text-center">
                     <p class="display-3 text-onelive font-weight-bolder mb-0">Let's hear it from our</p>
@@ -143,7 +143,7 @@
 </section>
 
 <!-- Featured articles section -->
-<section>
+<section class="section">
     <div class="container mt-5 mb-5">
         <h1 class="display-3 text-center mb-5">Featured Articles</h1>
         <!--Featured stories goes here-->

--- a/scholarx/2022/index.html
+++ b/scholarx/2022/index.html
@@ -120,8 +120,8 @@
 </section>
 
 <!-- success stories section -->
-<section class="section"
-    style="display: flex; align-items: center; justify-content: center; background-color: #f4f5f7;">
+<section class="section bg-secondary"
+    style="display: flex; align-items: center; justify-content: center;">
     <div class="container row">
         <div class="pr-md-5 col-md-6" style="display: flex; justify-content: center; padding:0rem 0rem">
             <img src="./images/success.png" alt="success illustration" style="height : 285px; ">


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1284

## Goals
The success-stories section on the scholarx 2022 page should have a different background color (background-color: #f4f5f7;), so that the users can clearly identify the section separately.

## Approach
Change the background color and fix the paddings accordingly

### Screenshots
![image](https://user-images.githubusercontent.com/83972174/194765702-9a97b5f5-0437-404e-9fbb-ae91fa97b1d9.png)

### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1287-sef-site.surge.sh/scholarx/2022

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Windows 10, Chrome latest
