### PR TITLE
Support hyperlinks in Success Stories page

### DIFF
--- a/scholarx/success-stories/index.html
+++ b/scholarx/success-stories/index.html
@@ -188,7 +188,7 @@
             </p>
             <ul>
                 {{#achievements}}
-                    <li>{{.}}</li>
+                    <li>{{{.}}}</li>
                 {{/achievements}}
             </ul>
             <hr>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1306

## Goals
Currently, there are a few URLs displayed on the scholarx success stories page. We need to display them inside a hyperlink.

## Approach
Update the google sheet and update the mustache template to display the hyperlinks.

### Screenshots
![image](https://user-images.githubusercontent.com/83972174/195521583-1da08301-5e45-4a4c-b297-0c9e04bda441.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1307-sef-site.surge.sh/scholarx/success-stories/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Windows 10, Chrome latest
