### PR TITLE
Reduce the width of "Our mentors and speakers are from" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,48 +59,48 @@
     </section>
 
     <section class="section">
-        <div class="container-fluid text-center">
+        <div class="container text-center">
             <div class="h4 font-weight-900 text-center text-capitalize mb-4">Our mentors and speakers are from
                 <span class="h6 align-text-top">*</span>
             </div>
             <div class="row pb-3 ml-4 ml-md-0">
-                <div class="col-md-2 offset-md-1 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 offset-md-1 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/google.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/facebook.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/microsoft.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/apple.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/linkedin.png">
                 </div>
-                <div class="col-md-2 offset-md-1 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 offset-md-1 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/mit.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/stanford.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/harvard.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/oxford.png">
                 </div>
-                <div class="col-md-2 col-6 mb-4 mt-3 pr-5">
+                <div class="col-md-2 col-6 mb-4 mt-3">
                     <img class="mx-auto img-fluid"
                          src="assets/img/logos/cambridge.png">
                 </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1305

## Goals
Reduce the width of "Our mentors and speakers are from" section

## Approach
Remove unwanted bootstrap classes

### Screenshots
![image](https://user-images.githubusercontent.com/97779686/195766875-7773ad53-8678-4a43-a656-6865780dc206.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1313-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
