### PR TITLE
Remove white outlines from buttons

### DIFF
--- a/onelive/archive/index.html
+++ b/onelive/archive/index.html
@@ -63,7 +63,7 @@
             </div>
             <div class="row justify-content-center mb-md-5">
                 <div class="col-9 text-center">
-                    <button class="btn btn-link btn-outline-white btn-info" id="btnLoadMore" onclick="loadYoutubeVideos()">
+                    <button class="btn btn-link border-0 btn-info" id="btnLoadMore" onclick="loadYoutubeVideos()">
                         Load More
                     </button>
                 </div>

--- a/onelive/index.html
+++ b/onelive/index.html
@@ -23,7 +23,6 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" rel="stylesheet">
     <!-- Argon CSS -->
     <link type="text/css" href="../assets/css/argon.css?v=1.0.1" rel="stylesheet">
-    <link type="text/css" href="../assets/css/argon.css?v=1.0.1" rel="stylesheet">
     <!-- global CSS -->
     <link type="text/css" href="../assets/css/global-custom.css" rel="stylesheet">
     <!-- onelive CSS -->

--- a/onelive/index.html
+++ b/onelive/index.html
@@ -23,6 +23,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css" rel="stylesheet">
     <!-- Argon CSS -->
     <link type="text/css" href="../assets/css/argon.css?v=1.0.1" rel="stylesheet">
+    <link type="text/css" href="../assets/css/argon.css?v=1.0.1" rel="stylesheet">
     <!-- global CSS -->
     <link type="text/css" href="../assets/css/global-custom.css" rel="stylesheet">
     <!-- onelive CSS -->
@@ -80,7 +81,7 @@
             </div>
             <div class="row justify-content-center mb-md-5">
                 <div class="col-9 text-center">
-                    <a href="archive/" class="btn btn-link btn-outline-white btn-info">SEE MORE</a>
+                    <a href="archive/" class="btn btn-link border-0 btn-info">SEE MORE</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1349 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Remove design breaking white outlines from 'SEE MORE' and 'LOAD MORE' buttons on One Live pages

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Remove the class btn-outline-white and replace it with border-0

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->

**Now:**
![image](https://user-images.githubusercontent.com/49517852/197007412-257962c1-c1ad-4c5c-b96c-47766fcd67a6.png)
![image](https://user-images.githubusercontent.com/49517852/197008186-b4ddfabf-c232-4631-9e88-55f824236058.png)

### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-1350-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
