### PR TITLE
Remove the upcoming events section from the onelive page 

### DIFF
--- a/onelive/index.html
+++ b/onelive/index.html
@@ -51,21 +51,6 @@
         </div>
     </section>
 
-    <!--  upcoming events section  -->
-    <section class="section section-secondary mb-0 pb-5" id="section-events">
-        <div class="container">
-            <div class="row justify-content-center mb-3">
-                <div class="col-9 text-center">
-                    <h1 class="display-3 text-center mb-5">Upcoming Events</h1>
-                </div>
-            </div>
-            <div class="row" id="upcoming-events">
-                <div class="col-md-12">
-                    <div class="h5 font-weight-normal text-muted text-center mt-4 status-text">Loading...</div>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <section class="section bg-secondary">
         <div class="container">


### PR DESCRIPTION


## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix  #1473


## Goals
On the onelive page, we have a [section displaying upcoming onelive events](https://sefglobal.org/onelive/#section-events). We no longer require that section because the onelive program is discontinued.

## Approach
Remove the upcoming events section


### Screenshots
![Screenshot (4)](https://user-images.githubusercontent.com/85789039/210197707-dc3f8c62-a83f-412e-a433-ec807b511c78.png)  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
<!---  ex: https://pr-1366-sef-site.surge.sh -->
<!---  Feel free to modify the link with the exact path -->
https://pr-1488-sef-site.surge.sh/onelive

##  Checklist
- [x] I have read and understood the [development best practices](https://handbook.sefglobal.org/organisation/engineering-team#development-best-practices) guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Related PRs
<!--- List any other related PRs --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
