### PR TITLE
Fix press coverage section tablet view

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,13 +401,14 @@
                              >
                     </a>
                 </div>
-                <div class="col-lg-4 col-sm-6 col-8 offset-2 offset-sm-0 my-2">
+                <div class="col-lg-4 col-sm-12 col-8 offset-2 offset-sm-0 my-2">
                     <a href="https://youtu.be/u-Jv1beNSI4" target="_blank">
                         <img class="mx-auto img-fluid"
                              src="assets/img/logos/iv.png"
                              data-toggle="tooltip" 
                              data-placement="bottom" 
                              title="IVolunteer International"
+                             style="max-height: 85px;"
                              >
                     </a>
                 </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #1523

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
The alignment of the last item in press coverage section in home page is off.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Align the last item to center in tablet view.

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot 2023-03-03 at 00 30 36](https://user-images.githubusercontent.com/103246998/222525973-fceaa41a-5bec-496e-9ccf-3d5738320bfd.jpg)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
<!---  ex: https://pr-1366-sef-site.surge.sh -->
<!---  Feel free to modify the link with the exact path -->
https://pr-1524-sef-site.surge.sh/

##  Checklist
- [x] I have read and understood the [development best practices](https://handbook.sefglobal.org/organisation/engineering-team#development-best-practices) guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Related PRs
<!--- List any other related PRs --> 

## Learning

