### PR TITLE
fix the issue of linking 'Learn more' button to handbook (#1606)

### DIFF
--- a/join-us.html
+++ b/join-us.html
@@ -56,7 +56,7 @@
                         <li><i class="fa fa-award mr-2"></i></i>Business Communication</li>
                         <li><i class="fa fa-award mr-2"></i></i>Programming</li>
                     </ul>
-                    <a href="#faq-section">
+                    <a href="https://handbook.sefglobal.org/engineering-team/team">
                         <button class="btn btn-default text-uppercase mt-2" href="examples">Learn more</button>
                     </a>
                 </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #<issue-number>
not get linked to the handbook when click the 'Learn more' btn on join our team page

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
changed the href to the handbook URL

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
<!---  ex: https://pr-1366-sef-site.surge.sh -->
<!---  Feel free to modify the link with the exact path -->
https://pr-{PR_NUMBER}-sef-site.surge.sh/

##  Checklist
- [x] I have read and understood the [development best practices](https://handbook.sefglobal.org/organisation/engineering-team#development-best-practices) guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Related PRs
<!--- List any other related PRs --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
