### PR TITLE
Fix the issue of Decreasing the engineering team page width

### DIFF
--- a/engineering-team/styles.css
+++ b/engineering-team/styles.css
@@ -1,42 +1,45 @@
+#btnPosts {
+  width: 100%;
+}
+
 .skeleton-box {
-    border-radius: 20px;
+  border-radius: 20px;
 }
 
 .skeleton-post-body {
-    padding: 15px 15px !important;
+  padding: 15px 15px !important;
 }
 
 .skeleton-post-body .skeleton-img {
-    background-color: hsl(210, 11%, 93%);
-    float: left;
-    width: 35px;
-    height: 35px;
-    overflow: hidden;
-    border-radius: 50%;
-    margin-right: 5px;
+  background-color: hsl(210, 11%, 93%);
+  float: left;
+  width: 35px;
+  height: 35px;
+  overflow: hidden;
+  border-radius: 50%;
+  margin-right: 5px;
 }
 
 .skeleton-author-name {
-    background-color: hsl(210, 11%, 93%);
-    padding: 15px !important;
-    margin-left: 40px;
-    border-radius: 10px;
+  background-color: hsl(210, 11%, 93%);
+  padding: 15px !important;
+  margin-left: 40px;
+  border-radius: 10px;
 }
 
 .skeleton-image {
-    background-color: hsl(210, 11%, 93%);
-    padding: 70px;
-    margin-bottom: 10px;
-    border-radius: 10px;
+  background-color: hsl(210, 11%, 93%);
+  padding: 70px;
+  margin-bottom: 10px;
+  border-radius: 10px;
 }
 
 .skeleton-topic {
-    background-color: hsl(210, 11%, 93%);
-    padding: 15px;
-    border-radius: 10px;
+  background-color: hsl(210, 11%, 93%);
+  padding: 15px;
+  border-radius: 10px;
 }
 
 .skeleton-profile {
-    background-color: hsl;
+  background-color: hsl;
 }
-


### PR DESCRIPTION
Fixed #1608 the issue related to the width of the engineering team page 

before

[
![296505062-c49b214b-0a34-4d8b-aebe-6bdbb1d827e9](https://github.com/sef-global/sef-site/assets/85481462/40ad0432-d752-447f-8de8-80c81d4b90e7)
](url)

after
<img width="959" alt="Screenshot 2024-03-30 184434" src="https://github.com/sef-global/sef-site/assets/85481462/7456ef09-7692-42f6-9389-b8917ef51bb5">


 [This is where I fixed the issue](https://sefglobal.org/engineering-team/)





