### PR TITLE
Fix the Learn More button redirecting problem on the Join Us page

### DIFF
--- a/join-us.html
+++ b/join-us.html
@@ -56,7 +56,7 @@
                         <li><i class="fa fa-award mr-2"></i></i>Business Communication</li>
                         <li><i class="fa fa-award mr-2"></i></i>Programming</li>
                     </ul>
-                    <a href="https://handbook.sefglobal.org/engineering-team/team">
+                    <a href="https://handbook.sefglobal.org/engineering-team/team" target="_blank">
                         <button class="btn btn-default text-uppercase mt-2" href="examples">Learn more</button>
                     </a>
                 </div>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
Fixing the issue of "Learn More" button on the Join Us page opening in the same page #1612

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
After clicking the "Learn More" button handbook will open from new tab

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Modified the "join-us.html" file. I used the attribute called "target='_blank' "

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
![Screenshot 2024-04-08 202512](https://github.com/sef-global/sef-site/assets/142712365/e2eb4dd2-2929-43a6-8118-63b64faaf390)

  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
<!---  ex: https://pr-1366-sef-site.surge.sh -->
<!---  Feel free to modify the link with the exact path -->
https://pr-1617-sef-site.surge.sh/


##  Checklist
- [x] I have read and understood the [development best practices](https://handbook.sefglobal.org/organisation/engineering-team#development-best-practices) guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

